### PR TITLE
Checks main file extension, if it's JS or an array proceed; else skip package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var gulp = require("gulp"),
+        path = require("path"),
 	gutil = require("gulp-util"),
 	through2 = require("through2"),
 	util = require("util"),
@@ -40,6 +41,7 @@ module.exports = function(filename, sources) {
 					var myData = JSON.parse(data);
 
 					if(!!myData.main) {
+                                                if( path.extname( myData.main ) != '.js' ) return;
 						var myMain = [].concat(myData.main),
 							mySourcePath = util.format("%s/%s", file.path, myMain[0]);
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function(filename, sources) {
 						callback();
 					}
 					else {
-						console.log(util.format("Skipping library @ %s. Bower.js is missing 'main' property or it is not a JS filtype.", file.path));
+						console.log(util.format("Skipping library @ %s. Bower.js is missing 'main' property or it is not a JS filetype.", file.path));
 						callback();
 					}
 				});

--- a/index.js
+++ b/index.js
@@ -40,8 +40,7 @@ module.exports = function(filename, sources) {
 
 					var myData = JSON.parse(data);
 
-					if(!!myData.main) {
-                                                if( path.extname( myData.main ) != '.js' ) return;
+					if(!!myData.main  && path.extname( myData.main ) == '.js') {
 						var myMain = [].concat(myData.main),
 							mySourcePath = util.format("%s/%s", file.path, myMain[0]);
 
@@ -51,7 +50,7 @@ module.exports = function(filename, sources) {
 						callback();
 					}
 					else {
-						console.log(util.format("Skipping library @ %s. Bower.js is missing 'main' property.", file.path));
+						console.log(util.format("Skipping library @ %s. Bower.js is missing 'main' property or it is not a JS filtype.", file.path));
 						callback();
 					}
 				});

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function(filename, sources) {
 
 					var myData = JSON.parse(data);
 
-					if(!!myData.main  && path.extname( myData.main ) == '.js') {
+					if(!!myData.main && (path.extname( myData.main ) == '.js' || myData.main.constructor === Array)) {
 						var myMain = [].concat(myData.main),
 							mySourcePath = util.format("%s/%s", file.path, myMain[0]);
 


### PR DESCRIPTION
This fixes the issue:
If you have a non-JS bower module as a dependency, it will also concat it with the JS modules. Needless to say this causes syntax errors.
