### PR TITLE
handle ignoredDependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,9 @@ module.exports = function(filename, sources) {
 			return mySources[name];
 		}));
 
+		myLibs = myLibs.filter(function(n){ return n != undefined });
+
+
 		myLibs = myLibs.concat(myFiles);
 
 		gulp.src(myLibs)


### PR DESCRIPTION
If ignoredDependecies are defined when running bower, this plugin will fail because an undefined path is added to the glob. Try running this example: https://gist.github.com/JCB-K/74055e6e250a97c6248a

This pull request removes undefined values from the myLibs array, avoiding the error.
